### PR TITLE
feat: stop record when user leave

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -112,6 +112,11 @@ function MyApp({ Component, pageProps }) {
         );
       };
 
+      window.addEventListener("beforeunload", (e) => {
+        localStorage.removeItem("enterTick");
+        localStorage.removeItem("operationId");
+      });
+
       window.addEventListener(
         "load",
         function () {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -208,19 +208,20 @@ function MyApp({ Component, pageProps }) {
         return event.target.id;
       };
 
+      let mouseWidget;
       window.addEventListener("mousedown", (event) => {
         mousedownTimetick = new Date().getTime();
+        const widgetId = findRightComponentId(event);
+        mouseWidget = widgetId
+          ? widgetId
+          : `Blank(${event.clientX}, ${event.clientY})`;
       });
 
       window.addEventListener("mouseup", (event) => {
         let startTime =
           mousedownTimetick - parseInt(localStorage.getItem("enterTick"));
         let duration = new Date().getTime() - mousedownTimetick;
-        const widgetId = findRightComponentId(event);
-        const widget = widgetId
-          ? widgetId
-          : `Blank(${event.clientX}, ${event.clientY})`;
-        let record = getFormatRecord(widget, startTime, duration);
+        let record = getFormatRecord(mouseWidget, startTime, duration);
         postClickRecord(record, async () => {
           const _ = await oprationIdPlus("mouseup");
         });

--- a/pages/admin.js
+++ b/pages/admin.js
@@ -188,9 +188,9 @@ export default function Admin() {
   };
 
   useEffect(() => {
-    localStorage.removeItem("enterTick");
-    localStorage.removeItem("operationId");
-    alert("Finish Capturing");
+    // localStorage.removeItem("enterTick");
+    // localStorage.removeItem("operationId");
+    // alert("Finish Capturing");
     const _ = getAllOperationSequences();
   }, []);
 

--- a/pages/courses.js
+++ b/pages/courses.js
@@ -215,16 +215,20 @@ export default function Courses() {
                       {item.courseName}
                     </div>
                   </Link>
-                  <Button
-                    id="pCourses-Status"
-                    className={style.rowSecond + " " + style.rowContent}
+                  <a
+                    className={`${style.rowSecond} ${style.rowContent}`}
                     style={{ color: "#3291f8 !important" }}
-                    onClick={() => {
-                      postBlueClick("pCourses-Status");
-                    }}
                   >
-                    {item.category}
-                  </Button>
+                    <div
+                      className={style.link}
+                      id="pCourses-Status"
+                      onClick={() => {
+                        postBlueClick("pCourses-Status");
+                      }}
+                    >
+                      {item.category}
+                    </div>
+                  </a>
                 </div>
               ))}
             </Stack>

--- a/styles/courses.module.css
+++ b/styles/courses.module.css
@@ -21,6 +21,15 @@
   height: 100%;
 }
 
+.link {
+  color: blue;
+  cursor: pointer;
+}
+
+.link:hover {
+  text-decoration: underline;
+}
+
 .rowHead {
   font-weight: bold;
   font-size: 26px !important;

--- a/styles/util.module.css
+++ b/styles/util.module.css
@@ -22,4 +22,5 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  cursor: pointer;
 }


### PR DESCRIPTION
- [x] 把mouseup里的记录控件id那两句话删掉，写到mousedown里。（_app.js里）即，鼠标按下时的位置算作交互位置。
- [x] signup和login的submit按钮外圈我开始做的是假的背景，改成真的按钮。改后的效果是：鼠标放在submit按钮外圈，也能从箭头变成小手的图标，达到可交互的假象。
- [x] blueclick都改成link形式。与蓝色字体交互时无任何显式的效果反馈给用户，只记录操作。
- [x] 用户离开时停止记录